### PR TITLE
Check return code, fail on error after dfu state

### DIFF
--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -338,6 +338,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
                     // Check for an error return code
                     if (!response.isSuccess()) {
                         fail(new McuMgrErrorException(response.getRc()));
+                        return;
                     }
 
                     McuMgrImageStateResponse.ImageSlot[] images = response.images;
@@ -416,6 +417,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
             // Check for an error return code
             if (!response.isSuccess()) {
                 fail(new McuMgrErrorException(response.getRc()));
+                return;
             }
             if (response.images.length != 2) {
                 fail(new McuMgrException("Test response does not contain enough info"));
@@ -499,6 +501,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
                     // Check for an error return code
                     if (!response.isSuccess()) {
                         fail(new McuMgrErrorException(response.getRc()));
+                        return;
                     }
                     if (response.images.length == 0) {
                         fail(new McuMgrException("Confirm response does not contain enough info"));


### PR DESCRIPTION
The firmware upgrade process coud fail in the response handler after most
states due accessing the length of a null array. The values of the
response may be null if the device response with an error return code.

This commit adds a check on the return code of the response before
accessing the values. If the return code indicates an error on the
device, the firmware upgrade will be failed with an
McuMgrErrorException.