### PR TITLE
Image upload: add sha to initial packet

### DIFF
--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -572,7 +572,6 @@ public class ImageManager extends McuManager {
                         boolean isMtuSet = setUploadMtu(mtu);
 
                         if (isMtuSet) {
-                            Log.e(TAG, "Upload MTU is too large for transport. MTU reset to " + mtu);
                             // If the MTU has been set successfully, restart the upload.
                             restartUpload();
                             return;


### PR DESCRIPTION
There is a new feature in Apache Mynewt which keeps track of unfinished
uploads by storing the hash of the image data. When a client sends the
initial upload packet (offset 0) with the hash that matches an
unfinished upload, the device will respond with the offset which the
previous upload left off at.

Since a SHA256 is a lot of bytes, the ImageManager sends only the first
3 bytes of the SHA which should be random enough to verify that the
images are the same.