### PR TITLE
Fix state in onUpgradeFailed callback

### DIFF
--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -310,8 +310,9 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
     }
 
     private synchronized void fail(McuMgrException error) {
+        State failedState = mState;
         cancelPrivate();
-        mInternalCallback.onUpgradeFailed(mState, error);
+        mInternalCallback.onUpgradeFailed(failedState, error);
     }
 
     private synchronized void cancelPrivate() {


### PR DESCRIPTION
State was reset to NONE before calling onUpgradeFailed for every all
firmware upgrade callbacks. This commit makes a temporary state variable
used in the callback before resetting the state to NONE.