### PR TITLE
Confirm slot0; check slot0 hash on response

### DIFF
--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -540,7 +540,7 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
                                 return;
                             }
                             // Check that the upgrade image has been confirmed
-                            if (!response.images[1].confirmed) {
+                            if (!response.images[1].pending) {
                                 fail(new McuMgrException("Image is not in a confirmed state."));
                                 return;
                             }


### PR DESCRIPTION
This commit fixes a potentially critical bug with TEST_AND_CONFIRM mode upgrades which occurs when the upgrade image fails to boot. Previously, after the new image boot failed and the device reboots into the old image, the firmware upgrade process would proceed to confirm and confirm the failed image (by hash) in slot 1. The device would run as it did previously until it got rebooted again, causing the device to boot into the failed image and brick itself.

This commit changes the confirm command to confirm the image in slot 0, regardless of hash. In the response the slot 0 image's hash is checked to verify the image booted correctly. If the image in slot 0 does not match the upgrade image, the upgrade is failed.