### PR TITLE
Requesting storage permission when file:// uri returned.

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -3,10 +3,29 @@
 	xmlns:android="http://schemas.android.com/apk/res/android"
 	xmlns:tools="http://schemas.android.com/tools">
 
+	<!--
+	 Bluetooth permission is required in order to communicate with Bluetooth LE devices.
+	-->
 	<uses-permission android:name="android.permission.BLUETOOTH"/>
+
+	<!--
+	 Bluetooth Admin permission is required in order to scan for Bluetooth LE devices.
+	-->
 	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
+	<!--
+	 Location permission is required from Android 6 to be able to scan for advertising
+	 Bluetooth LE devices. Some BLE devices, called beacons, may be used to position the phone.
+	 This is to ensure that the user agrees to do so.
+	 This app does not use this location information in any way.
+	 -->
 	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+	<!--
+	 This permission is required to read a file content when the file browser app have returned
+	 file:// URI, instead of content:// URI. This way of passing URIs is deprecated, but still
+	 may be used by some File Browser apps. Since Android 6+ this permission is a runtime type
+	 permission and must be requested on runtime. Check FileBrowserFragment class.
+	 -->
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
 	<application
 		android:allowBackup="false"

--- a/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileBrowserFragment.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/fragment/mcumgr/FileBrowserFragment.java
@@ -6,8 +6,10 @@
 
 package io.runtime.mcumgr.sample.fragment.mcumgr;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -15,6 +17,7 @@ import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.CursorLoader;
@@ -30,17 +33,22 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import io.runtime.mcumgr.sample.R;
+import io.runtime.mcumgr.sample.utils.Utils;
 
 public abstract class FileBrowserFragment extends Fragment implements LoaderManager.LoaderCallbacks<Cursor> {
 	private static final String TAG = FileBrowserFragment.class.getSimpleName();
+
+	private static final int REQUEST_WRITE_EXTERNAL_STORAGE = 1023; // random number
 
 	private static final int SELECT_FILE_REQ = 1;
 	private static final int LOAD_FILE_LOADER_REQ = 2;
 	private static final String EXTRA_FILE_URI = "uri";
 
 	private static final String SIS_DATA = "data";
+	private static final String SIS_URI = "uri";
 
 	private byte[] mFileContent;
+	private Uri mFileUri;
 
 	@Override
 	public void onCreate(@Nullable final Bundle savedInstanceState) {
@@ -48,6 +56,7 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
 
 		if (savedInstanceState != null) {
 			mFileContent = savedInstanceState.getByteArray(SIS_DATA);
+			mFileUri = savedInstanceState.getParcelable(SIS_URI);
 		}
 	}
 
@@ -55,6 +64,7 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
 	public void onSaveInstanceState(@NonNull final Bundle outState) {
 		super.onSaveInstanceState(outState);
 		outState.putByteArray(SIS_DATA, mFileContent);
+		outState.putParcelable(SIS_URI, mFileUri);
 	}
 
 	/**
@@ -116,6 +126,20 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
 	protected abstract void onFileLoadingFailed(@StringRes final int error);
 
 	@Override
+	public void onRequestPermissionsResult(final int requestCode,
+										   @NonNull final String[] permissions,
+										   @NonNull final int[] grantResults) {
+		switch (requestCode) {
+			case REQUEST_WRITE_EXTERNAL_STORAGE:
+				if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+					loadFile(mFileUri);
+				}
+				mFileUri = null;
+				break;
+		}
+	}
+
+	@Override
 	public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
 		super.onActivityResult(requestCode, resultCode, data);
 
@@ -134,18 +158,25 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
 
 					// The URI returned may be of 2 schemes: file:// (legacy) or content:// (new)
 					if (uri.getScheme().equals("file")) {
-						// TODO This may require WRITE_EXTERNAL_STORAGE permission!
-						final String path = uri.getPath();
-						final String fileName = path.substring(path.lastIndexOf('/'));
-
-						final File file = new File(path);
-						final int fileSize = (int) file.length();
-						onFileSelected(fileName, fileSize);
-						try {
-							loadContent(new FileInputStream(file));
-						} catch (final FileNotFoundException e) {
-							Log.e(TAG, "File not found", e);
-							onFileLoadingFailed(R.string.file_loader_error_no_uri);
+						if (Utils.isStoragePermissionsGranted(requireContext())) {
+							loadFile(uri);
+						} else {
+							if (Utils.isStoragePermissionDeniedForever(requireActivity())) {
+								Snackbar.make(getView(), R.string.file_loader_permission_denied, Snackbar.LENGTH_LONG)
+										.setAction(R.string.menu_settings, v -> {
+											final Intent intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+											intent.setData(Uri.fromParts("package", requireContext().getPackageName(), null));
+											startActivity(intent);
+										})
+										.show();
+								return;
+							}
+							mFileUri = uri;
+							Utils.markStoragePermissionRequested(requireContext());
+							requestPermissions(
+									new String[] { Manifest.permission.WRITE_EXTERNAL_STORAGE },
+									REQUEST_WRITE_EXTERNAL_STORAGE
+							);
 						}
 					} else {
 						// File name and size must be obtained from Content Provider
@@ -241,6 +272,27 @@ public abstract class FileBrowserFragment extends Fragment implements LoaderMana
 		} else {
 			Toast.makeText(requireContext(), R.string.file_loader_error_no_file_browser,
 					Toast.LENGTH_SHORT).show();
+		}
+	}
+
+	/**
+	 * Loads file given in file:// scheme. This will not work with content:// scheme.
+	 * The app must have WRITE_EXTERNAL_STORAGE permission in order to read the file.
+	 *
+	 * @param uri the file URI in file:// scheme.
+	 */
+	private void loadFile(@NonNull final Uri uri) {
+		final String path = uri.getPath();
+		final String fileName = path.substring(path.lastIndexOf('/') + 1);
+
+		final File file = new File(path);
+		final int fileSize = (int) file.length();
+		onFileSelected(fileName, fileSize);
+		try {
+			loadContent(new FileInputStream(file));
+		} catch (final FileNotFoundException e) {
+			Log.e(TAG, "File not found", e);
+			onFileLoadingFailed(R.string.file_loader_error_no_uri);
 		}
 	}
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/utils/Utils.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/utils/Utils.java
@@ -21,10 +21,12 @@ import android.support.v4.content.ContextCompat;
 public class Utils {
 	private static final String PREFS_LOCATION_NOT_REQUIRED = "location_not_required";
 	private static final String PREFS_PERMISSION_REQUESTED = "permission_requested";
+	private static final String PREFS_STORAGE_PERMISSION_REQUESTED = "storage_permission_requested";
 
 	/**
 	 * Checks whether Bluetooth is enabled.
-	 * @return true if Bluetooth is enabled, false otherwise.
+	 *
+	 * @return True if Bluetooth is enabled, false otherwise.
 	 */
 	public static boolean isBleEnabled() {
 		final BluetoothAdapter adapter = BluetoothAdapter.getDefaultAdapter();
@@ -34,17 +36,59 @@ public class Utils {
 	/**
 	 * Checks for required permissions.
 	 *
-	 * @return true if permissions are already granted, false otherwise.
+	 * @return True if permissions are already granted, false otherwise.
+	 */
+	public static boolean isStoragePermissionsGranted(final Context context) {
+		return ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+				== PackageManager.PERMISSION_GRANTED;
+	}
+
+	/**
+	 * Returns true if storage permission has been requested at least twice and
+	 * user denied it, and checked 'Don't ask again'.
+	 *
+	 * @param activity the activity.
+	 * @return True if permission has been denied and the popup will not come up any more,
+	 * false otherwise.
+	 */
+	public static boolean isStoragePermissionDeniedForever(final Activity activity) {
+		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(activity);
+
+		return !isStoragePermissionsGranted(activity) // Storage permission must be denied
+				&& preferences.getBoolean(PREFS_STORAGE_PERMISSION_REQUESTED, false) // Permission must have been requested before
+				&& !ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE); // This method should return false
+	}
+
+	/**
+	 * The first time an app requests a permission there is no 'Don't ask again' checkbox and
+	 * {@link ActivityCompat#shouldShowRequestPermissionRationale(Activity, String)} returns false.
+	 * This situation is similar to a permission being denied forever, so to distinguish both cases
+	 * a flag needs to be saved.
+	 *
+	 * @param context the context.
+	 */
+	public static void markStoragePermissionRequested(final Context context) {
+		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
+		preferences.edit().putBoolean(PREFS_STORAGE_PERMISSION_REQUESTED, true).apply();
+	}
+
+	/**
+	 * Checks for required permissions.
+	 *
+	 * @return True if permissions are already granted, false otherwise.
 	 */
 	public static boolean isLocationPermissionsGranted(final Context context) {
-		return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+		return ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION)
+				== PackageManager.PERMISSION_GRANTED;
 	}
 
 	/**
 	 * Returns true if location permission has been requested at least twice and
 	 * user denied it, and checked 'Don't ask again'.
-	 * @param activity the activity
-	 * @return true if permission has been denied and the popup will not come up any more, false otherwise
+	 *
+	 * @param activity the activity.
+	 * @return True if permission has been denied and the popup will not come up any more,
+	 * false otherwise.
 	 */
 	public static boolean isLocationPermissionDeniedForever(final Activity activity) {
 		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(activity);
@@ -55,10 +99,12 @@ public class Utils {
 	}
 
 	/**
-	 * On some devices running Android Marshmallow or newer location services must be enabled in order to scan for Bluetooth LE devices.
+	 * On some devices running Android Marshmallow or newer location services must be enabled in
+	 * order to scan for Bluetooth LE devices.
 	 * This method returns whether the Location has been enabled or not.
 	 *
-	 * @return true on Android 6.0+ if location mode is different than LOCATION_MODE_OFF. It always returns true on Android versions prior to Marshmallow.
+	 * @return true on Android 6.0+ if location mode is different than LOCATION_MODE_OFF.
+	 * It always returns true on Android versions prior to Marshmallow.
 	 */
 	public static boolean isLocationEnabled(final Context context) {
 		if (isMarshmallowOrAbove()) {
@@ -74,10 +120,11 @@ public class Utils {
 	}
 
 	/**
-	 * Location enabled is required on some phones running Android Marshmallow or newer (for example on Nexus and Pixel devices).
+	 * Location enabled is required on some phones running Android Marshmallow or newer
+	 * (for example on Nexus and Pixel devices).
 	 *
-	 * @param context the context
-	 * @return false if it is known that location is not required, true otherwise
+	 * @param context the context.
+	 * @return False if it is known that location is not required, true otherwise.
 	 */
 	public static boolean isLocationRequired(final Context context) {
 		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -86,9 +133,11 @@ public class Utils {
 
 	/**
 	 * When a Bluetooth LE packet is received while Location is disabled it means that Location
-	 * is not required on this device in order to scan for LE devices. This is a case of Samsung phones, for example.
-	 * Save this information for the future to keep the Location info hidden.
-	 * @param context the context
+	 * is not required on this device in order to scan for LE devices.
+	 * This is a case of Samsung phones, for example. Save this information for the future to
+	 * keep the Location info hidden.
+	 *
+	 * @param context the context.
 	 */
 	public static void markLocationNotRequired(final Context context) {
 		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
@@ -100,7 +149,8 @@ public class Utils {
 	 * {@link ActivityCompat#shouldShowRequestPermissionRationale(Activity, String)} returns false.
 	 * This situation is similar to a permission being denied forever, so to distinguish both cases
 	 * a flag needs to be saved.
-	 * @param context the context
+	 *
+	 * @param context the context.
 	 */
 	public static void markLocationPermissionRequested(final Context context) {
 		final SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);

--- a/sample/src/main/res/values/strings_file_loader.xml
+++ b/sample/src/main/res/values/strings_file_loader.xml
@@ -9,4 +9,5 @@
 	<string name="file_loader_error_no_file_browser">File Browser app not found.</string>
 	<string name="file_loader_error_no_uri">No file found.</string>
 	<string name="file_loader_error_loading_file_failed">Reading file failed.</string>
+	<string name="file_loader_permission_denied">Storage permission is denied.</string>
 </resources>


### PR DESCRIPTION
When the File Browser app returns an URI with file:// scheme, storage permission is required in order to read the file content. In this, and only this condition, the app will ask for WRITE_EXTERNAL_STORAGE permission.
Content:// type scheme URIs do not require this permission.
To test it you may try Total Commander app, and select (file uri) in when selecting the file.