### PR TITLE
Allow to cancel upgrade in Validate state

### DIFF
--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeController.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeController.java
@@ -21,6 +21,12 @@ public interface FirmwareUpgradeController {
 
     /**
      * Cancel the firmware upgrade.
+     * The firmware may be cancelled in
+     * {@link FirmwareUpgradeManager.State#VALIDATE} or
+     * {@link FirmwareUpgradeManager.State#UPLOAD} state.
+     * The manager does not try to recover the original firmware after the test or confirm commands
+     * have been sent. To undo the upload, confirm the image that have been moved to slot 1 during
+     * swap.
      */
     void cancel();
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -39,7 +39,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 		}
 
 		public boolean canCancel() {
-			return this == UPLOADING || this == PAUSED;
+			return this == VALIDATING || this == UPLOADING || this == PAUSED;
 		}
 	}
 


### PR DESCRIPTION
This adds an option to cancel an upgrade when it's in VALIDATE state.
This also includes situation, when the device must be reset to make the slot 1 erasable.