### PR TITLE
Support for Android API 18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
+        // classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
     }
-}
-
-ext {
-    mcuMgrVersion = "0.6.0"
 }
 
 allprojects {

--- a/mcumgr-android-lib/build.gradle
+++ b/mcumgr-android-lib/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.android.library'
 // group='com.github.runtimeco'
 
 ext {
-    mcuMgrVersion = "0.6.0"
+    mcuMgrVersion = "0.6.2"
 }
 
 android {

--- a/mcumgr-android-lib/build.gradle
+++ b/mcumgr-android-lib/build.gradle
@@ -31,17 +31,18 @@ dependencies {
     // Import the BLE Library
     api 'no.nordicsemi.android:ble:2.0-alpha6'
 
-    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    // Import the Timber library
+    implementation 'com.jakewharton.timber:timber:4.7.1'
+
+    // Import CBOR parser
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.6'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
 
     // Test
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     testImplementation 'junit:junit:4.12'
-
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.6'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
-    implementation 'com.jakewharton.timber:timber:4.7.1'
 }
 
 // build a jar with source files

--- a/mcumgr-android-lib/build.gradle
+++ b/mcumgr-android-lib/build.gradle
@@ -6,8 +6,12 @@
  */
 
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-group='com.github.runtimeco'
+// apply plugin: 'com.github.dcendents.android-maven'
+// group='com.github.runtimeco'
+
+ext {
+    mcuMgrVersion = "0.6.0"
+}
 
 android {
     compileSdkVersion 28

--- a/mcumgr-android-lib/build.gradle
+++ b/mcumgr-android-lib/build.gradle
@@ -17,7 +17,7 @@ android {
     compileSdkVersion 28
     buildToolsVersion '27.0.3'
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode 1
         versionName mcuMgrVersion

--- a/mcumgr-android-lib/build.gradle
+++ b/mcumgr-android-lib/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc01'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.6'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.6'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'

--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -115,14 +115,16 @@ public abstract class McuManager {
     }
 
     /**
-     * Sets the upload MTU. MTU must be between 23 and 1024.
+     * Sets the upload MTU. MTU must be between 20 and 1024.
+     * This is transport independent value, so should be equal to the maximum length of a packet
+     * with selected transport.
      *
-     * @param mtu the MTU to use for image upload.
+     * @param mtu the MTU to use for packets.
      * @return True if the upload has been set, false otherwise.
      */
     public synchronized boolean setUploadMtu(int mtu) {
-        if (mtu < 23) {
-            Timber.e("MTU is too small! Must be greater than 23.");
+        if (mtu < 20) {
+            Timber.e("MTU is too small! Must be greater than 20.");
             return false;
         } else if (mtu > 1024) {
             Timber.e("MTU is too large! Must be less than 1024.");
@@ -134,7 +136,7 @@ public abstract class McuManager {
     }
 
     /**
-     * Returns the upload MTU. MTU must be between 23 and 1024.
+     * Returns the upload MTU. MTU must be between 20 and 1024.
      *
      * @return The MTY.
      */

--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/managers/FsManager.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/managers/FsManager.java
@@ -520,8 +520,8 @@ public class FsManager extends McuManager {
                 return cborData.length + 20 + 5;
             } else {
                 byte[] cborData = CBOR.toBytes(overheadTestMap);
-                // 8 bytes for McuMgr header; 2 bytes for data length; 3 for command type and att ID
-                return cborData.length + 8 + 2 + 3;
+                // 8 bytes for McuMgr header; 2 bytes for data length
+                return cborData.length + 8 + 2;
             }
         } catch (IOException e) {
             Timber.e(e, "Error while calculating packet overhead");

--- a/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
+++ b/mcumgr-android-lib/src/main/java/io/runtime/mcumgr/managers/ImageManager.java
@@ -599,8 +599,8 @@ public class ImageManager extends McuManager {
                 return cborData.length + 20 + 5;
             } else {
                 byte[] cborData = CBOR.toBytes(overheadTestMap);
-                // 8 bytes for McuMgr header; 2 bytes for data length; 3 for command type and att ID
-                return cborData.length + 8 + 2 + 3;
+                // 8 bytes for McuMgr header; 2 bytes for data length
+                return cborData.length + 8 + 2;
             }
         } catch (IOException e) {
             Timber.e(e, "Error while calculating packet overhead");


### PR DESCRIPTION
This PR adds support for older versions of Android. 
Before API 21, the BLE MTU was always 23 and couldn't be changed. To send longer SMP packets, they need to be split into at-most-20-byte long BLE packets and then merged on the device (based on the packet length from the header). However, this feature must be supported by the SMP server on the device.
So far it is not: https://github.com/apache/mynewt-mcumgr/issues/6, so by default this is disabled (max packet length is set to be equal to MTU-3)
Short packets (i.e. echo) may still be sent on pre-Lollipop Android devices.

This PR also removes an unused dependency from the lib's gradle file.
