### PR TITLE
Refactor logging to use SLF4J

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     api 'no.nordicsemi.android:ble:2.0-beta5'
 
     // Logging
-    implementation 'org.slf4j:slf4j-android:1.7.7'
+    implementation 'org.slf4j:slf4j-api:1.7.25'
 
     // Import mcumgr-core
     api project(':mcumgr-core')

--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     // Import the BLE Library
     api 'no.nordicsemi.android:ble:2.0-beta5'
 
-    // Import the Timber library
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    // Logging
+    implementation 'org.slf4j:slf4j-android:1.7.7'
 
     // Import mcumgr-core
     api project(':mcumgr-core')

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -13,6 +13,9 @@ import android.bluetooth.BluetoothGattService;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -40,7 +43,6 @@ import no.nordicsemi.android.ble.exception.BluetoothDisabledException;
 import no.nordicsemi.android.ble.exception.DeviceDisconnectedException;
 import no.nordicsemi.android.ble.exception.InvalidRequestException;
 import no.nordicsemi.android.ble.exception.RequestFailedException;
-import timber.log.Timber;
 
 /**
  * The McuMgrBleTransport is an implementation for the {@link McuMgrScheme#BLE} transport scheme.
@@ -51,6 +53,8 @@ import timber.log.Timber;
  */
 @SuppressWarnings("unused")
 public class McuMgrBleTransport extends BleManager<BleManagerCallbacks> implements McuMgrTransport {
+
+    private static final Logger LOG = LoggerFactory.getLogger(McuMgrBleTransport.class);
 
     public final static UUID SMP_SERVICE_UUID =
             UUID.fromString("8D53DC1D-1DB7-4CD3-868B-8A527460AA84");
@@ -330,12 +334,12 @@ public class McuMgrBleTransport extends BleManager<BleManagerCallbacks> implemen
         protected boolean isRequiredServiceSupported(@NonNull BluetoothGatt gatt) {
             mSmpService = gatt.getService(SMP_SERVICE_UUID);
             if (mSmpService == null) {
-                Timber.e("Device does not support SMP service");
+                LOG.error("Device does not support SMP service");
                 return false;
             }
             mSmpCharacteristic = mSmpService.getCharacteristic(SMP_CHAR_UUID);
             if (mSmpCharacteristic == null) {
-                Timber.e("Device does not support SMP characteristic");
+                LOG.error("Device does not support SMP characteristic");
                 return false;
             } else {
                 final int rxProperties = mSmpCharacteristic.getProperties();
@@ -343,7 +347,7 @@ public class McuMgrBleTransport extends BleManager<BleManagerCallbacks> implemen
                         BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE) > 0;
                 boolean notify = (rxProperties & BluetoothGattCharacteristic.PROPERTY_NOTIFY) > 0;
                 if (!write || !notify) {
-                    Timber.e("SMP characteristic does not support either write (%s) or notify (%s)", write, notify);
+                    LOG.error("SMP characteristic does not support either write ({}) or notify ({})", write, notify);
                     return false;
                 }
             }

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:16.0.1'
 
     // Logging
-    implementation 'org.slf4j:slf4j-android:1.7.7'
+    implementation 'org.slf4j:slf4j-api:1.7.25'
 
     // Import CBOR parser
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.6'

--- a/mcumgr-core/build.gradle
+++ b/mcumgr-core/build.gradle
@@ -27,8 +27,12 @@ android {
 }
 
 dependencies {
-    // Import the Timber library
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+
+    // Annotations
+    implementation 'org.jetbrains:annotations:16.0.1'
+
+    // Logging
+    implementation 'org.slf4j:slf4j-android:1.7.7'
 
     // Import CBOR parser
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.9.6'

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/McuManager.java
@@ -9,6 +9,8 @@ package io.runtime.mcumgr;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.text.ParseException;
@@ -22,13 +24,14 @@ import java.util.TimeZone;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.util.CBOR;
-import timber.log.Timber;
 
 /**
  * TODO
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public abstract class McuManager {
+
+    private final static Logger LOG = LoggerFactory.getLogger(McuManager.class);
 
     // Transport constants
     private final static int DEFAULT_MTU = 515;
@@ -124,10 +127,10 @@ public abstract class McuManager {
      */
     public synchronized boolean setUploadMtu(int mtu) {
         if (mtu < 20) {
-            Timber.e("MTU is too small! Must be greater than 20.");
+            LOG.error("MTU is too small! Must be greater than 20.");
             return false;
         } else if (mtu > 1024) {
-            Timber.e("MTU is too large! Must be less than 1024.");
+            LOG.error("MTU is too large! Must be less than 1024.");
             return false;
         } else {
             mMtu = mtu;
@@ -368,7 +371,7 @@ public abstract class McuManager {
         try {
             return mcumgrFormat.parse(dateString);
         } catch (ParseException e) {
-            Timber.e(e, "Converting string to Date failed");
+            LOG.error("Converting string to Date failed", e);
             return null;
         }
     }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/DefaultManager.java
@@ -7,7 +7,6 @@
 
 package io.runtime.mcumgr.managers;
 
-import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
@@ -10,6 +10,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.Arrays;
 
@@ -18,11 +21,12 @@ import io.runtime.mcumgr.McuMgrHeader;
 import io.runtime.mcumgr.McuMgrScheme;
 import io.runtime.mcumgr.exception.McuMgrCoapException;
 import io.runtime.mcumgr.util.CBOR;
-import timber.log.Timber;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class McuMgrResponse {
+
+    private final static Logger LOG = LoggerFactory.getLogger(McuMgrResponse.class);
 
     /**
      * The raw return code found in most McuMgr response payloads. If a rc value is not explicitly
@@ -76,7 +80,7 @@ public class McuMgrResponse {
         try {
             return CBOR.toString(mPayload);
         } catch (IOException e) {
-            Timber.e(e, "Failed to parse response");
+            LOG.error("Failed to parse response", e);
         }
         return null;
     }
@@ -97,7 +101,7 @@ public class McuMgrResponse {
      */
     public int getReturnCodeValue() {
         if (mReturnCode == null) {
-            Timber.w("Response does not contain a McuMgr return code.");
+            LOG.warn("Response does not contain a McuMgr return code.");
             return 0;
         } else {
             return mReturnCode.value();
@@ -245,7 +249,7 @@ public class McuMgrResponse {
                                                                  Class<T> type) throws IOException, McuMgrCoapException {
         // If the code class indicates a CoAP error response, throw a McuMgrCoapException
         if (codeClass == 4 || codeClass == 5) {
-            Timber.e("Received CoAP Error response, throwing McuMgrCoapException");
+            LOG.error("Received CoAP Error response, throwing McuMgrCoapException");
             throw new McuMgrCoapException(bytes, codeClass, codeDetail);
         }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     // Timber & SLF4J
     implementation 'com.arcao:slf4j-timber:3.0@aar'
+    implementation 'com.jakewharton.timber:timber:4.7.1'
 
     // Mcu Mgr
     implementation project(':mcumgr-ble')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -52,8 +52,8 @@ dependencies {
     // Brings the new BluetoothLeScanner API to older platforms
     implementation 'no.nordicsemi.android.support.v18:scanner:1.1.0'
 
-    // Timber
-    implementation 'com.jakewharton.timber:timber:4.7.1'
+    // Timber & SLF4J
+    implementation 'com.arcao:slf4j-timber:3.0@aar'
 
     // Mcu Mgr
     implementation project(':mcumgr-ble')

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/SingleLiveEvent.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/SingleLiveEvent.java
@@ -12,6 +12,7 @@ import android.arch.lifecycle.Observer;
 import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.Log;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/SingleLiveEvent.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/SingleLiveEvent.java
@@ -12,7 +12,6 @@ import android.arch.lifecycle.Observer;
 import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 


### PR DESCRIPTION
In a previous discussion, I had convinced myself that Timber was the end all logging solution. However input from users has exposed a weakness: since many apps also use Timber, version mismatches can occur causing build issues. This would force users to change their timber version to match ours. As a support library, this is less than ideal, especially for a "non-essential" feature like logging.

Therefore I have performed a refactor of the `core` and `ble` modules to use SLF4J. The sample app now contains a dependency for [slf4j-timber](https://github.com/arcao/slf4j-timber) which contains a logging factory and adapter for routing logs from McuManager's SLF4J to Timber.